### PR TITLE
fix: remove duplicate character in regex character class (#18)

### DIFF
--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NonNls;
 public final class PlayerEmailValidation {
 
   @NonNls private static final String QUOTED_STRING_REGEX = "\"(?:[^\"\\\\]|\\\\\\p{ASCII})*\"";
-  @NonNls private static final String ATOM_REGEX = "[^()<>@,;:\\\\\".\\[\\] \\x28\\p{Cntrl}]+";
+  @NonNls private static final String ATOM_REGEX = "[^()<>@,;:\\\\\".\\[\\] \\p{Cntrl}]+";
 
   @NonNls
   private static final String WORD_REGEX = "(?:" + ATOM_REGEX + "|" + QUOTED_STRING_REGEX + ")";


### PR DESCRIPTION
## Description

Closes #18

Removes a duplicate character in the regex character class of `ATOM_REGEX` in [PlayerEmailValidation.java](cci:7://file:///c:/Uni/Winter_26/SCM/GitProject/triplea/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java:0:0-0:0), flagged by SonarQube.

## Problem

The `ATOM_REGEX` character class `[^()<>@,;:\\".\[\] \x28\p{Cntrl}]+` contained `\x28`, which is the hex escape for `(` (ASCII 0x28 = 40). Since `(` was already listed explicitly at the start of the class, `\x28` was redundant.

## Changes

Removed `\x28` from the character class:

```diff
- "[^()<>@,;:\\\\\".\\[\\] \\x28\\p{Cntrl}]+"
+ "[^()<>@,;:\\\\\".\\[\\] \\p{Cntrl}]+"
```

