### PR TITLE
Fix java:S3824: Replace Map.get() and put() with Map.merge() in Battl…

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/BattleRecordsList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/BattleRecordsList.java
@@ -21,13 +21,10 @@ public class BattleRecordsList extends GameDataComponent {
       final Map<Integer, BattleRecords> recordList,
       final int currentRound,
       final BattleRecords other) {
-    final BattleRecords current = recordList.get(currentRound);
-    if (current == null) {
-      recordList.put(currentRound, other);
-      return;
-    }
-    current.addRecord(other);
-    recordList.put(currentRound, current);
+    recordList.merge(currentRound, other, (current, newRecords) -> {
+      current.addRecord(newRecords);
+      return current;
+    });
   }
 
   public static void removeRecords(


### PR DESCRIPTION
Refactor BattleRecordsList to use Map.merge() instead of get() and put()
  
Resolves SonarQube java:S3824 issue by replacing the manual Map.get() and
null check block with Map.merge() to add or update records while strictly 
preserving the original behavior of direct storage when the key is absent.
