### PR TITLE
Technical Debt - Change the visibility of this constructor to "protected". Fix #26

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/AbstractMoveDescription.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/AbstractMoveDescription.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data;
 
 import java.io.Serializable;
 import java.util.Collection;
+
 import lombok.Getter;
 
 /** Superclass for any action that describes the movement or placement of units. */
@@ -10,7 +11,7 @@ public abstract class AbstractMoveDescription implements Serializable {
   private static final long serialVersionUID = -6615899716448836002L;
   private final Collection<Unit> units;
 
-  public AbstractMoveDescription(final Collection<Unit> units) {
+  protected AbstractMoveDescription(final Collection<Unit> units) {
     this.units = units;
   }
 


### PR DESCRIPTION
This fixes issue #26 

the visibility for the constructor of `AbstractMoveDescription` was changed from `public` to `protected`.

<img width="834" height="418" alt="Screenshot 2026-03-06 at 11 40 52 PM" src="https://github.com/user-attachments/assets/80507fff-a099-4c2f-ba3f-5e719e6962a1" />
