### PR TITLE
fix: extract shared player-selection clone from BanPlayerAction and BootPlayerAction

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/network/ui/BanPlayerAction.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/network/ui/BanPlayerAction.java
@@ -1,13 +1,9 @@
 package games.strategy.engine.framework.network.ui;
 
-import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
-import java.util.TreeSet;
 import javax.swing.AbstractAction;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JComboBox;
 import javax.swing.JOptionPane;
 
 /** An action for banning a player from a network game. */
@@ -24,34 +20,13 @@ public class BanPlayerAction extends AbstractAction {
 
   @Override
   public void actionPerformed(final ActionEvent e) {
-    final DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
-    final JComboBox<String> combo = new JComboBox<>(model);
-    model.addElement("");
-    for (final INode node : new TreeSet<>(messenger.getNodes())) {
-      if (!node.equals(messenger.getLocalNode())) {
-        model.addElement(node.getName());
-      }
-    }
-    if (model.getSize() == 1) {
-      JOptionPane.showMessageDialog(
-          parent, "No remote players", "No Remote Players", JOptionPane.ERROR_MESSAGE);
-      return;
-    }
-    final int selectedOption =
-        JOptionPane.showConfirmDialog(
-            parent, combo, "Select player to ban", JOptionPane.OK_CANCEL_OPTION);
-    if (selectedOption != JOptionPane.OK_OPTION) {
-      return;
-    }
-    final String name = (String) combo.getSelectedItem();
-    for (final INode node : messenger.getNodes()) {
-      if (node.getName().equals(name)) {
-        final String ip = node.getAddress().getHostAddress();
-        final String mac = messenger.getPlayerMac(node.getPlayerName());
-        messenger.banPlayer(ip, mac);
-        messenger.removeConnection(node);
-        return;
-      }
-    }
+    PlayerSelectionUi.selectPlayer(parent, messenger, "Select player to ban")
+        .ifPresent(
+            node -> {
+              final String ip = node.getAddress().getHostAddress();
+              final String mac = messenger.getPlayerMac(node.getPlayerName());
+              messenger.banPlayer(ip, mac);
+              messenger.removeConnection(node);
+            });
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/network/ui/BootPlayerAction.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/network/ui/BootPlayerAction.java
@@ -1,13 +1,9 @@
 package games.strategy.engine.framework.network.ui;
 
-import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
-import java.util.TreeSet;
 import javax.swing.AbstractAction;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JComboBox;
 import javax.swing.JOptionPane;
 
 /** An action for booting a player from a network game. */
@@ -24,30 +20,7 @@ public class BootPlayerAction extends AbstractAction {
 
   @Override
   public void actionPerformed(final ActionEvent e) {
-    final DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
-    final JComboBox<String> combo = new JComboBox<>(model);
-    model.addElement("");
-    for (final INode node : new TreeSet<>(messenger.getNodes())) {
-      if (!node.equals(messenger.getLocalNode())) {
-        model.addElement(node.getName());
-      }
-    }
-    if (model.getSize() == 1) {
-      JOptionPane.showMessageDialog(
-          parent, "No remote players", "No Remote Players", JOptionPane.ERROR_MESSAGE);
-      return;
-    }
-    final int selectedOption =
-        JOptionPane.showConfirmDialog(
-            parent, combo, "Select player to remove", JOptionPane.OK_CANCEL_OPTION);
-    if (selectedOption != JOptionPane.OK_OPTION) {
-      return;
-    }
-    final String name = (String) combo.getSelectedItem();
-    for (final INode node : messenger.getNodes()) {
-      if (node.getName().equals(name)) {
-        messenger.removeConnection(node);
-      }
-    }
+    PlayerSelectionUi.selectPlayer(parent, messenger, "Select player to remove")
+        .ifPresent(messenger::removeConnection);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/network/ui/PlayerSelectionUi.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/network/ui/PlayerSelectionUi.java
@@ -1,0 +1,48 @@
+package games.strategy.engine.framework.network.ui;
+
+import games.strategy.net.INode;
+import games.strategy.net.IServerMessenger;
+import java.awt.Component;
+import java.util.Optional;
+import java.util.TreeSet;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JComboBox;
+import javax.swing.JOptionPane;
+
+/** Shared UI helper for selecting a remote player from a network game. */
+class PlayerSelectionUi {
+
+  private PlayerSelectionUi() {}
+
+  /**
+   * Prompts the host to select a remote player from the current game session.
+   *
+   * @param parent the parent component for dialogs
+   * @param messenger the server messenger providing node information
+   * @param dialogTitle the title shown on the player selection dialog
+   * @return the selected {@link INode}, or empty if cancelled or no remote players exist
+   */
+  static Optional<INode> selectPlayer(
+      final Component parent, final IServerMessenger messenger, final String dialogTitle) {
+    final DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
+    final JComboBox<String> combo = new JComboBox<>(model);
+    model.addElement("");
+    for (final INode node : new TreeSet<>(messenger.getNodes())) {
+      if (!node.equals(messenger.getLocalNode())) {
+        model.addElement(node.getName());
+      }
+    }
+    if (model.getSize() == 1) {
+      JOptionPane.showMessageDialog(
+          parent, "No remote players", "No Remote Players", JOptionPane.ERROR_MESSAGE);
+      return Optional.empty();
+    }
+    final int selectedOption =
+        JOptionPane.showConfirmDialog(parent, combo, dialogTitle, JOptionPane.OK_CANCEL_OPTION);
+    if (selectedOption != JOptionPane.OK_OPTION) {
+      return Optional.empty();
+    }
+    final String name = (String) combo.getSelectedItem();
+    return messenger.getNodes().stream().filter(n -> n.getName().equals(name)).findFirst();
+  }
+}


### PR DESCRIPTION
- `BanPlayerAction` and `BootPlayerAction` contained ~40 lines of near-identical player-selection UI code (146 tokens flagged by PMD CPD)
- Extracted shared logic into a new `PlayerSelectionUi` helper class with a single static `selectPlayer(...)` method returning `Optional<INode>`
- Both action classes now only implement their specific post-selection behavior

## Files Changed

- `PlayerSelectionUi.java` (new)
- `BanPlayerAction.java` 
- `BootPlayerAction.java` 

Closes #44