### PR TITLE
Vulnerability Fix: upgrading eclipse-temurim from 25 to 26 to fix ope…

### DIFF
--- a/game-app/game-headless/Dockerfile
+++ b/game-app/game-headless/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25
+FROM eclipse-temurin:26
 
 ENV BOT_PORT_NUMBER=4000
 EXPOSE $BOT_PORT_NUMBER


### PR DESCRIPTION
…nssl vulnerability. Fixes #58

Used Synk to detect a medium severity vulnerability in openssl@3.0.13-0ubuntu3.9 and @3.0.13-0ubuntu3.9.

<img width="1306" height="335" alt="image" src="https://github.com/user-attachments/assets/0f08fc30-1124-4199-bff5-c17a34bf5664" />

Fixed the issue by upgrading the docker file from version 25 to 26. 

