### PR TITLE
Fix java:S5852: Prevent catastrophic backtracking in LookAndFeel regex

### DIFF
--- a/game-app/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
@@ -24,7 +24,7 @@ public final class DefaultSubstanceLookAndFeelManager implements SubstanceLookAn
   private static UIManager.LookAndFeelInfo newLookAndFeelInfoForSkin(final SkinInfo skinInfo) {
     return new UIManager.LookAndFeelInfo(
         "Substance " + skinInfo.getDisplayName(),
-        skinInfo.getClassName().replaceFirst("(?<=\\.)(\\w+)Skin$", "Substance$1LookAndFeel"));
+        skinInfo.getClassName().replaceFirst("(?<=\\.)(\\w++)Skin$", "Substance$1LookAndFeel"));
   }
 
   @Override


### PR DESCRIPTION
Resolves a SonarQube Denial of Service (ReDoS) vulnerability warning in DefaultSubstanceLookAndFeelManager. Added a possessive quantifier (\w++) to ensure linear time complexity and prevent the regex engine from backtracking endlessly on malformed strings.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
