### PR TITLE
fi(vulnerability): XXE vulnerability in XML parsing and broken Vault.java compilation (java:S2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -74,19 +74,12 @@ public class Vault {
           }
           final SecretKey key = bytesToKey(secretKeyBytes);
           final Cipher cipher;
-          // Correction by Ali and Omar
           try {
-        	    cipher = Cipher.getInstance(ALGORITHM);
-
-        	    GCMParameterSpec spec = new GCMParameterSpec(128, iv); // iv must come with encrypted data
-        	    cipher.init(Cipher.DECRYPT_MODE, key, spec);
-
-          	} catch (NoSuchAlgorithmException
-        	        | InvalidKeyException
-        	        | NoSuchPaddingException
-        	        | InvalidAlgorithmParameterException e) {
-        	    throw new IllegalStateException(e);
-        		}
+            cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, key);
+          } catch (final NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException e) {
+            throw new IllegalStateException(e);
+          }
           
           final byte[] encrypted = unverifiedValues.remove(id);
           final byte[] decrypted;

--- a/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/XmlMapper.java
+++ b/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/XmlMapper.java
@@ -24,6 +24,7 @@ public class XmlMapper implements Closeable {
 
   public XmlMapper(final InputStream inputStream) throws XmlParsingException {
     final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+    inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
     try {
       xmlStreamReader = inputFactory.createXMLStreamReader(inputStream);
     } catch (final XMLStreamException e) {

--- a/lib/xml-reader/src/main/java/org/triplea/generic/xml/scanner/XmlScanner.java
+++ b/lib/xml-reader/src/main/java/org/triplea/generic/xml/scanner/XmlScanner.java
@@ -17,6 +17,7 @@ public class XmlScanner {
 
   public XmlScanner(final InputStream inputStream) throws XMLStreamException {
     final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+    inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
     xmlStreamReader = inputFactory.createXMLStreamReader(inputStream);
   }
 


### PR DESCRIPTION
SonarQube Cloud flagged two BLOCKER-level XXE (XML External Entity) vulnerabilities in the XML parsing module. Both `XmlMapper.java` and `XmlScanner.java` create an XMLInputFactory without disabling external entity support, which could allow attackers to read files, perform SSRF, or cause denial of service through crafted XML input.

Side fix: `Vault.java` has a compilation error introduced in a previous commit that references undefined variables and missing imports (GCMParameterSpec, iv, InvalidAlgorithmParameterException), which breaks the SonarQube cloud CI build.

Changes:
- XmlMapper.java (line 26): disable external entity support on `XMLInputFactory`
- XmlScanner.java (line 19): disable external entity support on `XMLInputFactory`
- Vault.java: fix compilation error in unlock method by reverting broken cipher init

#65 

<img width="1234" height="418" alt="Image" src="https://github.com/user-attachments/assets/44a5bd3f-cebd-43fd-96f4-9a387b88ae70" />